### PR TITLE
Support Kodi Style Movie Extras

### DIFF
--- a/Contents/Code/localmedia.py
+++ b/Contents/Code/localmedia.py
@@ -186,16 +186,24 @@ def findAssets(metadata, media_title, paths, type, parts=[]):
 
             # Files following the "-extra" convention.
             else:
+              found = False
               if not fn.startswith('.') and fn.endswith('-deletedscene') and ext[1:] in config.VIDEO_EXTS:
                 Log('Found %s extra: %s' % ('deleted', f))
                 title = ' '.join(fn.split('-')[:-1])
                 extras.append({'type' : 'deleted', 'title' : helpers.unicodize(title), 'file' : os.path.join(path, f)})
+                found = True
               else:
                 for key in extra_type_map.keys():
                   if not fn.startswith('.') and fn.endswith('-' + key) and ext[1:] in config.VIDEO_EXTS:
                     Log('Found %s extra: %s' % (key, f))
                     title = ' '.join(fn.split('-')[:-1])
                     extras.append({'type' : key, 'title' : helpers.unicodize(title), 'file' : os.path.join(path, f)})
+                    found = True
+              # Flag unlabeled extras in the extras folder as scene.
+              if not found:
+                Log('Found %s extra: %s' % ('Unknown (Flagged as Scene)', f))
+                title = fn
+                extras.append({'type' : 'scene', 'title' : helpers.unicodize(title), 'file' : os.path.join(path, f)})
     
         # Make sure extras are sorted alphabetically and by type.
         type_order = ['trailer', 'behindthescenes', 'interview', 'deleted', 'scene', 'sample', 'featurette', 'short']

--- a/Contents/Code/localmedia.py
+++ b/Contents/Code/localmedia.py
@@ -161,11 +161,16 @@ def findAssets(metadata, media_title, paths, type, parts=[]):
 
           # Files following the "-extra" convention.
           else:
-            for key in extra_type_map.keys():
-              if not fn.startswith('.') and fn.endswith('-' + key) and ext[1:] in config.VIDEO_EXTS:
-                Log('Found %s extra: %s' % (key, f))
-                title = ' '.join(fn.split('-')[:-1])
-                extras.append({'type' : key, 'title' : helpers.unicodize(title), 'file' : os.path.join(path, f)})
+            if not fn.startswith('.') and fn.endswith('-deletedscene') and ext[1:] in config.VIDEO_EXTS:
+              Log('Found %s extra: %s' % ('deleted', f))
+              title = ' '.join(fn.split('-')[:-1])
+              extras.append({'type' : 'deleted', 'title' : helpers.unicodize(title), 'file' : os.path.join(path, f)})
+            else:
+              for key in extra_type_map.keys():
+                if not fn.startswith('.') and fn.endswith('-' + key) and ext[1:] in config.VIDEO_EXTS:
+                  Log('Found %s extra: %s' % (key, f))
+                  title = ' '.join(fn.split('-')[:-1])
+                  extras.append({'type' : key, 'title' : helpers.unicodize(title), 'file' : os.path.join(path, f)})
     
         # Look for filenames following the "-extra" convention and a couple of other special cases in the "Extras" Folder.
         if extras_folder != '':
@@ -181,11 +186,16 @@ def findAssets(metadata, media_title, paths, type, parts=[]):
 
             # Files following the "-extra" convention.
             else:
-              for key in extra_type_map.keys():
-                if not fn.startswith('.') and fn.endswith('-' + key) and ext[1:] in config.VIDEO_EXTS:
-                  Log('Found %s extra: %s' % (key, f))
-                  title = ' '.join(fn.split('-')[:-1])
-                  extras.append({'type' : key, 'title' : helpers.unicodize(title), 'file' : os.path.join(path, f)})
+              if not fn.startswith('.') and fn.endswith('-deletedscene') and ext[1:] in config.VIDEO_EXTS:
+                Log('Found %s extra: %s' % ('deleted', f))
+                title = ' '.join(fn.split('-')[:-1])
+                extras.append({'type' : 'deleted', 'title' : helpers.unicodize(title), 'file' : os.path.join(path, f)})
+              else:
+                for key in extra_type_map.keys():
+                  if not fn.startswith('.') and fn.endswith('-' + key) and ext[1:] in config.VIDEO_EXTS:
+                    Log('Found %s extra: %s' % (key, f))
+                    title = ' '.join(fn.split('-')[:-1])
+                    extras.append({'type' : key, 'title' : helpers.unicodize(title), 'file' : os.path.join(path, f)})
     
         # Make sure extras are sorted alphabetically and by type.
         type_order = ['trailer', 'behindthescenes', 'interview', 'deleted', 'scene', 'sample', 'featurette', 'short']


### PR DESCRIPTION
This pull request adds support for scanning the Extras folder. It utilizes the same logic as scanning inside the root folder for extras with the addition of untagged files in the extras folder are given a default tag.

Both Kodi and Emby require that all Movie Extras be stored in a subfolder titled Extras ([Kodi Requirements](http://kodi.wiki/view/Add-on:VideoExtras#Extras_Folder)  [Emby Requirements](https://github.com/MediaBrowser/Wiki/wiki/Movie%20naming#user-content-movie-extras)). Plex treats the extras folder [exactly the same](https://github.com/plexinc-plugins/Scanners.bundle/blob/d8ca7d014d07ff68f3013a2728801a5ad50a6325/Contents/Resources/Common/VideoFiles.py#L14) as the folder structures it does support, but it does not scan inside it. 

Accepting this pull request will allow users of both Kodi and Emby to access load their movies without having to rearrange their file system. ([Here](https://forums.plex.tv/discussion/192704/extras-folder-naming-compatible-with-both-plex-and-kodi) is someone requesting exactly that.)